### PR TITLE
Fix username index in development (sqlite3)

### DIFF
--- a/db/migrate/20151024204508_add_lowercase_username_index_to_users.rb
+++ b/db/migrate/20151024204508_add_lowercase_username_index_to_users.rb
@@ -1,9 +1,20 @@
 class AddLowercaseUsernameIndexToUsers < ActiveRecord::Migration
   def up
-    execute "CREATE UNIQUE INDEX index_users_on_lower_username ON users (lower(username))"
+    create_index_sql = 'CREATE UNIQUE INDEX index_users_on_lower_username ON users'
+    create_index_sql +=
+      if database_adapter == 'sqlite3'
+        ' (username COLLATE NOCASE)'
+      else
+        ' (lower(username))'
+      end
+    execute create_index_sql
   end
 
   def down
     execute "DROP INDEX index_users_on_lower_username"
+  end
+
+  def database_adapter
+    Rails.application.config.database_configuration[Rails.env]['adapter']
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151113004355) do
+ActiveRecord::Schema.define(version: 20151027171552) do
 
   create_table "notifications", force: :cascade do |t|
     t.integer  "user_id",    null: false
@@ -35,8 +35,6 @@ ActiveRecord::Schema.define(version: 20151113004355) do
     t.datetime "feedback_approved_at"
   end
 
-  add_index "participants", ["feedback", "feedback_approved_at"], name: "index_participants_on_feedback_idx"
-  add_index "participants", ["feedback_type", "feedback_approved_at"], name: "index_participants_on_feedback_type_idx"
   add_index "participants", ["trade_id"], name: "index_participants_on_trade_id"
   add_index "participants", ["user_id"], name: "index_participants_on_user_id"
 
@@ -56,5 +54,6 @@ ActiveRecord::Schema.define(version: 20151113004355) do
   end
 
   add_index "users", ["auth_uid"], name: "index_users_on_auth_uid"
+  add_index "users", ["username"], name: "index_users_on_lower_username", unique: true
 
 end


### PR DESCRIPTION
**Why:**
The migration adding the unique index to the username field was failing locally (w/ sqlite3), since its
syntax was specific to postgres (used in production).

**How:**
Conditionally build the SQL used to add the index, depending on which database adapter is being used.

Note: This removed a couple of feedback indexes from the db/schema file - I assume these were removed at some other point, since there is no migration for them, but the schema file was never re-committed.
